### PR TITLE
8/Django all auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ DATABASE_URL="" # line 14
 - do NOT forget to add the paths to your `local-cdn` and `staticfiles/vendor`
   to your `.gitignore` if for some reason you didn' pull it in the git clone of this repo.
 - Whitenoise for content storage for prod, at least short term.
+- Make sure that the django-all-auth-ui is installed for it's own style
+
+# Login
+- We are using AllAuth for login, using the emails as primary(at first it will be username and email)
+check the docs
+`https://docs.allauth.org/en/latest/account/views.html`
+
+- `https://github.com/danihodovic/django-allauth-ui`
 
 # django commands
   - Why do we use a django manage.py command and not just a python module? well, as soon as you make it a command, you have access to everything inside settings.py.
@@ -58,3 +66,14 @@ DATABASE_URL="" # line 14
    Might look for D-S on dropbox since it sounds funny, no realiable, but funny.
 
 - another time we need to use our own custom domain name for gmails
+
+- implement in the allauth/layouts base.html the navbar and footer, you can import the link from our original base
+into the header and the script too, if it's not already there
+
+- `src/templates/base/messages.html` use the messages framework from django to let the user he loged in or out
+`https://docs.djangoproject.com/en/5.1/ref/contrib/messages/`
+
+  {% include 'base/messages.html' with messages=messages %} 
+  remember that piece of code.
+
+- Read `https://docs.djangoproject.com/en/dev/topics/email/#file-backend`

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ check the docs
 - you used pampita email.
 - you can test it with `python manage.py sendtestemail --admin`
 
+# Implemnented AllAuth for authentication
+- If you want to see all the new urls
+  just turn the settings.py
+  TEMPLATE section to False, navigate to some url and watch all the paths
+- `https://docs.allauth.org/en/latest/`
+- `https://github.com/danihodovic/django-allauth-u`
+
 # TODO
  - read about context processors
 
@@ -77,3 +84,5 @@ into the header and the script too, if it's not already there
   remember that piece of code.
 
 - Read `https://docs.djangoproject.com/en/dev/topics/email/#file-backend`
+
+- TEST WITH A NEW EMAIL AND CHECK EMAIL VERIFICATION

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ dj-database-url
 requests
 whitenoise
 django-allauth[socialaccount]
+django-allauth-ui
+django-widget-tweaks
+slippers

--- a/src/cfehome/settings.py
+++ b/src/cfehome/settings.py
@@ -68,9 +68,13 @@ INSTALLED_APPS = [
     'visit',
     'management',
     # third-party-apps
+    'allauth_ui',
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
+    'allauth.socialaccount.providers.github',
+    'widget_tweaks',
+    'slippers',
 ]
 
 MIDDLEWARE = [
@@ -151,10 +155,14 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # Django Allauth Config
 LOGIN_REDIRECT_URL = '/'
+# we can change the login method here
 ACCOUNT_AUTHENTICATION_METHOD = 'username_email'
+# you NEED to check your email verification
 ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
 ACCOUNT_EMAIL_SUBJECT_PREFIX = '[CFE]'
 ACCOUNT_EMAIL_REQUIRED = True
+# UI theme
+ALLAUTH_UI_THEME = 'light'
 
 AUTHENTICATION_BACKENDS = [
     # ...

--- a/src/templates/allauth/layouts/base.html
+++ b/src/templates/allauth/layouts/base.html
@@ -1,0 +1,71 @@
+{# djlint:off H006 #}
+{% load i18n %}
+{% load static %}
+{% load allauth_ui %}
+<!DOCTYPE html>
+<html data-theme="{% allauth_ui_theme %}">
+    <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>
+            {% block head_title %}
+            {% endblock head_title %}
+        </title>
+        {% block extra_head %}
+            
+            <link rel="stylesheet" href="{% static 'allauth_ui/output.css' %}">
+            
+        {% endblock extra_head %}
+    </head>
+    <body class="min-h-screen bg-base-300">
+        
+        {% block body %}
+            {% if messages %}
+                {% for message in messages %}
+                    <div role="alert"
+                         class="text-sm md:text-base alert alert-{{ message.tags }}">
+                        <span><strong>{{ message }}</strong></span>
+                    </div>
+                {% endfor %}
+            {% endif %}
+            {% block content %}
+            {% endblock content %}
+            <div class="mx-auto [&_a]:link text-sm flex flex-col md:flex-row items-center justify-center gap-3 mt-3">
+                {% if user.is_authenticated %}
+                    {% url 'account_email' as email_url %}
+                    {% if email_url %}
+                        <a href="{{ email_url }}">{% trans "Change Email" %}</a>
+                    {% endif %}
+                    {% url 'account_change_password' as change_password_url %}
+                    {% if change_password_url %}
+                        <a href="{{ change_password_url }}">{% trans "Change Password" %}</a>
+                    {% endif %}
+                    {% url 'mfa_index' as mfa_url %}
+                    {% if mfa_url %}
+                        <a href="{{ mfa_url }}">{% trans "Two-Factor Authentication" %}</a>
+                    {% endif %}
+                    {% url 'usersessions_list' as usersessions_list_url %}
+                    {% if usersessions_list_url %}
+                        <a href="{{ usersessions_list_url }}">{% trans "Sessions" %}</a>
+                    {% endif %}
+                    {% url 'account_logout' as logout_url %}
+                    {% if logout_url %}
+                        <a href="{{ logout_url }}">{% trans "Sign Out" %}</a>
+                    {% endif %}
+                {% else %}
+                    {% url 'account_login' as login_url %}
+                    {% if login_url %}
+                        <a href="{{ login_url }}">{% trans "Sign In" %}</a>
+                    {% endif %}
+                    {% url 'account_signup' as signup_url %}
+                    {% if signup_url %}
+                        <a href="{{ signup_url }}">{% trans "Sign Up" %}</a>
+                    {% endif %}
+                {% endif %}
+            </div>
+            {% include 'base/js.html' %}
+        {% endblock body %}
+        {% block extra_body %}
+        {% endblock extra_body %}
+    </body>
+</html>

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -9,6 +9,7 @@
 </head>
     <body>
         {% include 'nav/navbar.html' %}
+        
         {% if request.user.is_authenticated %}
             You are a user
         {% else %}

--- a/src/templates/base/messages.html
+++ b/src/templates/base/messages.html
@@ -1,0 +1,8 @@
+{% if messages %}
+    {% for message in messages %}
+        <div role="alert"
+                class="text-sm md:text-base alert alert-{{ message.tags }}">
+            <span><strong>{{ message }}</strong></span>
+        </div>
+    {% endfor %}
+{% endif %}


### PR DESCRIPTION
implemented AllAuth for authentication and it's own UI
if you want to see all the new urls
just turn the settings.py
TEMPLATE section to False, navigate to some url and watch all the paths
Read Todo list in readme

# Implemnented AllAuth for authentication
- If you want to see all the new urls
  just turn the settings.py
  TEMPLATE section to False, navigate to some url and watch all the paths
- `https://docs.allauth.org/en/latest/`
- `https://github.com/danihodovic/django-allauth-u`
- 
# todo 
- got to fix the ui in order to reflect the navabr and footer
- TEST WITH A NEW EMAIL AND CHECK EMAIL VERIFICATION

# Screenshots
accounts/signup/
![image](https://github.com/user-attachments/assets/ef492637-25a1-44d2-a01c-3f43babf991f)
accounts/login
![image](https://github.com/user-attachments/assets/5fff188d-d55f-4b31-a178-b94e1ec1dd56)
accounts/logout/
![image](https://github.com/user-attachments/assets/2cead405-b1a5-42d0-8546-d5d002799172)
